### PR TITLE
Add CI component to Github Actions workflow

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,11 +1,23 @@
-name: Deploy Production
-on:
-  push:
-    branches:
-    - master
+name: Build and deploy
+on: push
+
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: yarn
+
+    - name: Build project
+      run: yarn build
+
   deploy:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v1
     - uses: webfactory/ssh-agent@v0.4.1
@@ -15,20 +27,20 @@ jobs:
         ssh -o StrictHostKeyChecking=no awards-web@134.209.0.181 /bin/bash << 'EOF'
           # report failure if any command fails
           set -e
-          
+
           # manually source nvm since bashrc exits early unless session is interactive
           source "$HOME/.nvm/nvm.sh"
-          
+
           # checkout changes
           cd "$HOME/awards-web"
           git fetch --all
           git reset --hard origin/master
-          
+
           # update deps, rebuild
           yarn
           yarn migrate
           yarn build-prod
-          
+
           # restart server
           sudo systemctl restart awards-web.service
         EOF

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -19,10 +19,21 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/master'
     steps:
+
     - uses: actions/checkout@v1
+
     - uses: webfactory/ssh-agent@v0.4.1
       with:
         ssh-private-key: ${{ secrets.AWARDS_WEB_SSH_KEY }}
+
+    - name: Create GitHub deployment
+      uses: chrnorm/deployment-action@v1.2.0
+      id: deployment
+      with:
+        token: ${{ github.token }}
+        target_url: https://animeawards.moe
+        environment: production
+
     - run: |
         ssh -o StrictHostKeyChecking=no awards-web@134.209.0.181 /bin/bash << 'EOF'
           # report failure if any command fails
@@ -44,3 +55,19 @@ jobs:
           # restart server
           sudo systemctl restart awards-web.service
         EOF
+
+    - name: Update deployment status (success)
+      if: success()
+      uses: chrnorm/deployment-status@v1.2.0
+      with:
+        token: ${{ github.token }}
+        state: success
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
+    - name: Update deployment status (failure)
+      if: failure()
+      uses: chrnorm/deployment-status@v1.2.0
+      with:
+        token: ${{ github.token }}
+        state: failure
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
Adds an explicit build step to the workflow that is run on all branch pushes, including PR branches. Also adds GitHub Deployment generation when deploying code to production.

Before this is ready to merge, I'll also be reworking the way deployment works so it doesn't rely on running the build step on the production server and can instead build on the Github Actions server and just move that build over.