### PR TITLE
Fix 2021 livestream + add section for 2022 on Archive page

### DIFF
--- a/frontend/results/pages/ArchiveLanding.vue
+++ b/frontend/results/pages/ArchiveLanding.vue
@@ -2,6 +2,20 @@
     <div class="container">
         <section class="section">
             <div class="container">
+                <h2 class="title is-size-3 has-text-gold has-text-centered has-flaired-underline pb-20">2022</h2>
+                <div class="control has-text-centered">
+                    <router-link to="/results" style="color:inherit">
+                        <button class="button is-large is-platinum is-outlined mb-10">Full Results</button>
+                    </router-link>
+                    <a target="_blank" href="https://www.youtube.com/watch?v=7dAmr9nV2_I" class="button is-large is-platinum is-outlined mb-10">Livestream</a>
+                    <router-link to="/acknowledgements" style="color:inherit">
+                        <button class="button is-large is-platinum is-outlined mb-10">Acknowledgements</button>
+                    </router-link>
+                    <router-link to="/about" style="color:inherit">
+                        <button class="button is-large is-platinum is-outlined mb-10">About/Credits</button>
+                    </router-link>
+                </div>
+                <br/>
                 <h2 class="title is-size-3 has-text-gold has-text-centered has-flaired-underline pb-20">2021</h2>
                 <div class="control has-text-centered">
                     <router-link to="/archive/2021" style="color:inherit">

--- a/frontend/results/pages/ArchiveLanding.vue
+++ b/frontend/results/pages/ArchiveLanding.vue
@@ -7,7 +7,7 @@
                     <router-link to="/archive/2021" style="color:inherit">
                         <button class="button is-large is-platinum is-outlined mb-10">Full Results</button>
                     </router-link>
-                    <a target="_blank" href="https://www.youtube.com/watch?v=7dAmr9nV2_I" class="button is-large is-platinum is-outlined mb-10">Livestream</a>
+                    <a target="_blank" href="https://www.youtube.com/watch?v=4wInZ-jcPHw" class="button is-large is-platinum is-outlined mb-10">Livestream</a>
                     <router-link to="/acknowledgements21" style="color:inherit">
                         <button class="button is-large is-platinum is-outlined mb-10">Acknowledgements</button>
                     </router-link>


### PR DESCRIPTION
Fixed url for 2021 livestream and added section for 2022 on archive page with links to /results, /acknowledgements, /about