### PR TITLE
Fix Allocations page + fetch applicant method

### DIFF
--- a/frontend/host/pages/Allocations.vue
+++ b/frontend/host/pages/Allocations.vue
@@ -231,7 +231,7 @@ export default {
 			await this.getAnswers();
 		}
 		if (!this.applicants) {
-			await this.getApplicantsByApp();
+			await this.getApplicantsByApp(4);
 		}
 		// Check if any jurors are allocated. If so, simply render them out.
 		if (this.jurors.length > 0) {

--- a/routes/application-api.js
+++ b/routes/application-api.js
@@ -794,7 +794,7 @@ apiApp.delete('/applicant/:id', async (request, response) => {
 			},
 			{
 				where: {
-					applicant_id: request.params.id,
+					applicant_id: parseInt(request.params.id),
 				},
 			},
 		);


### PR DESCRIPTION
Reverted change in Allocations that sometimes resulted in an invalid API call, and added parseInt to the get applicants by id method which should fix the number of applications display